### PR TITLE
Configure view_log_action for viewer token use

### DIFF
--- a/client.go
+++ b/client.go
@@ -24,6 +24,8 @@ type Client struct {
 	Component string
 	// Version is an identifier for the specific version of this component, usually a git SHA
 	Version string
+	// ViewLogAction is the action logged when a Viewer Token is used, default is 'audit.log.view'
+	ViewLogAction string
 }
 
 // NewClient creates a new retraced api client that can be used to send events
@@ -107,6 +109,7 @@ func (c *Client) GetViewerToken(groupID string, isAdmin bool, targetID string) (
 	params := url.Values{}
 	params.Add("group_id", groupID)
 	params.Add("is_admin", strconv.FormatBool(isAdmin))
+	params.Add("view_log_action", c.ViewLogAction)
 
 	if targetID != "" {
 		params.Add("target_id", targetID)

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,14 @@
+package retraced
+
+import "log"
+
+// Initialize a new client with your projectID and API key and then configure options.
+func ExampleClient() {
+	client, err := NewClient("f4228ca2220d4d0a89d39a93f9987658", "ce6eba2ba9534e94ad48624079bcccf6")
+	if err != nil {
+		log.Fatal(err)
+	}
+	client.Component = "Web Dashboard"
+	client.Version = "0.3.0"
+	client.ViewLogAction = "audit.log.view"
+}


### PR DESCRIPTION
I documented an example of how to set config options rather than change the constructor signatures.