### PR TITLE
Fix events pager panic, add test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM golang:1.11
+
+RUN go get github.com/satori/go.uuid
+RUN go get github.com/stretchr/testify/assert
+
+WORKDIR /go/src/github.com/retracedhq/retraced-go

--- a/client.go
+++ b/client.go
@@ -158,7 +158,7 @@ func (c *Client) GetViewerToken(groupID string, isAdmin bool, actorID string, ta
 }
 
 // Query searches for events using the Publisher API's GraphQL endpoint.
-func (c *Client) Query(sq *StructuredQuery, mask *EventNodeMask, pageSize int) (*EventsConnection, error) {
+func (c *Client) Query(sq *StructuredQuery, mask *EventNodeMask, pageSize int) (EventsPager, error) {
 	url := fmt.Sprintf("%s/publisher/v1/project/%s/graphql", c.Endpoint, c.projectID)
 	ec := &EventsConnection{
 		url:             url,

--- a/interface.go
+++ b/interface.go
@@ -1,0 +1,11 @@
+package retraced
+
+type EventsPager interface {
+	NextPage() error
+	TotalPages() int
+	HasNextPage() bool
+	HasPreviousPage() bool
+	CurrentPageNumber() int
+	CurrentResults() []*EventNode
+	TotalCount() int
+}

--- a/mock.go
+++ b/mock.go
@@ -1,0 +1,50 @@
+package retraced
+
+import (
+	"errors"
+	"sync"
+)
+
+type MockEventsPager struct {
+	currentPage int
+	Pages       [][]*EventNode
+	sync.Mutex
+}
+
+func (p *MockEventsPager) NextPage() error {
+	p.Lock()
+	defer p.Unlock()
+	if !p.HasNextPage() {
+		return errors.New("no next page")
+	}
+	p.currentPage++
+	return nil
+}
+
+func (p *MockEventsPager) TotalPages() int {
+	return len(p.Pages)
+}
+
+func (p *MockEventsPager) HasNextPage() bool {
+	return p.currentPage < len(p.Pages)-1
+}
+
+func (p *MockEventsPager) HasPreviousPage() bool {
+	return p.currentPage > 0
+}
+
+func (p *MockEventsPager) CurrentPageNumber() int {
+	return p.currentPage
+}
+
+func (p *MockEventsPager) CurrentResults() []*EventNode {
+	return p.Pages[p.currentPage]
+}
+
+func (p *MockEventsPager) TotalCount() int {
+	var total int
+	for _, page := range p.Pages {
+		total += len(page)
+	}
+	return total
+}

--- a/stream_test.go
+++ b/stream_test.go
@@ -1,0 +1,25 @@
+package retraced
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStreamFixPanic(t *testing.T) {
+	s := &Stream{
+		ec: &MockEventsPager{
+			Pages: [][]*EventNode{
+				{{}, {}, {}},
+				{{}, {}},
+			},
+		},
+	}
+	for i := 0; i < s.ec.TotalCount(); i++ {
+		_, err := s.Read()
+		assert.NoError(t, err)
+	}
+	_, err := s.Read()
+	assert.Equal(t, io.EOF, err)
+}

--- a/tests/graphql_test.go
+++ b/tests/graphql_test.go
@@ -80,14 +80,14 @@ func TestClientQuery(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Len(t, eventsConn.CurrentResults, 3)
-	assert.Equal(t, 10, eventsConn.TotalCount)
+	assert.Len(t, eventsConn.CurrentResults(), 3)
+	assert.Equal(t, 10, eventsConn.TotalCount())
 	assert.True(t, eventsConn.HasNextPage())
 	assert.False(t, eventsConn.HasPreviousPage())
-	assert.Equal(t, 1, eventsConn.CurrentPageNumber)
+	assert.Equal(t, 1, eventsConn.CurrentPageNumber())
 	assert.Equal(t, 4, eventsConn.TotalPages())
 
-	for _, node := range eventsConn.CurrentResults {
+	for _, node := range eventsConn.CurrentResults() {
 		assert.NotEmpty(t, node.ID)
 		assert.Equal(t, "go.test", node.Action)
 		assert.NotEmpty(t, node.Group.ID)
@@ -119,8 +119,8 @@ func TestClientQuery(t *testing.T) {
 	assert.NoError(t, eventsConn.NextPage())
 	assert.NoError(t, eventsConn.NextPage())
 
-	assert.Equal(t, 10, eventsConn.TotalCount)
-	assert.Equal(t, 4, eventsConn.CurrentPageNumber)
+	assert.Equal(t, 10, eventsConn.TotalCount())
+	assert.Equal(t, 4, eventsConn.CurrentPageNumber())
 	assert.Equal(t, 4, eventsConn.TotalPages())
 	assert.True(t, eventsConn.HasPreviousPage())
 	assert.False(t, eventsConn.HasNextPage())


### PR DESCRIPTION
```
root@07326b8407b9:/go/src/github.com/retracedhq/retraced-go# go test -timeout 30s github.com/retracedhq/retraced-go -run ^TestStreamFixPanic$
--- FAIL: TestStreamFixPanic (0.00s)
panic: runtime error: index out of range [recovered]
	panic: runtime error: index out of range

goroutine 5 [running]:
testing.tRunner.func1(0xc000144300)
	/usr/local/go/src/testing/testing.go:792 +0x387
panic(0x790900, 0xacea60)
	/usr/local/go/src/runtime/panic.go:513 +0x1b9
github.com/retracedhq/retraced-go.(*Stream).Read(0xc00000c4c0, 0x0, 0x0, 0x0)
	/go/src/github.com/retracedhq/retraced-go/stream.go:42 +0x1c4
github.com/retracedhq/retraced-go.TestStreamFixPanic(0xc000144300)
	/go/src/github.com/retracedhq/retraced-go/stream_test.go:20 +0x229
testing.tRunner(0xc000144300, 0x80da88)
	/usr/local/go/src/testing/testing.go:827 +0xbf
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:878 +0x353
FAIL	github.com/retracedhq/retraced-go	0.026s
root@07326b8407b9:/go/src/github.com/retracedhq/retraced-go#
```