### PR TITLE
Support TypeScript and Go formats when unmarshaling fields

### DIFF
--- a/fields_test.go
+++ b/fields_test.go
@@ -1,0 +1,41 @@
+package retraced
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     string
+		expected Fields
+	}{
+		{
+			name:     "GQL format",
+			data:     `[{"key": "abc", "value": "xyz"}]`,
+			expected: Fields{"abc": "xyz"},
+		},
+		{
+			name: "Go format",
+			data: `{"abc": "xyz", "is_true": true}`,
+			expected: Fields{
+				"abc":     "xyz",
+				"is_true": "true",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fields := Fields{}
+			if err := json.Unmarshal([]byte(test.data), &fields); err != nil {
+				t.Errorf("UnmarshalJSON failed: %v", err)
+				return
+			}
+			assert.New(t).Equal(test.expected, fields, "Fields should be equal")
+		})
+	}
+}


### PR DESCRIPTION
When fields are sent to Retraced API, they are returned formatted as `[{key: "", value: ""},...]`

However, when the object is marshaled locally in Go code, it can no longer be unmarshaled again because the format is `{"key": "value", ...}`